### PR TITLE
Add drag and drop sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # super-duper-invention
 
 This repository hosts a simple React TODO application scaffolded with [Vite](https://vitejs.dev/).
-The app lets you add items to a list and remove them again, demonstrating basic state management in React while keeping the codebase minimal. Type a task and press **Enter** or click **Add** to append it to the list.
+The app lets you add items to a list, remove them again, and reorder them by dragging and dropping. This demonstrates basic state management in React while keeping the codebase minimal. Type a task and press **Enter** or click **Add** to append it to the list.
 
 ## Getting started
 

--- a/my-app/src/App.jsx
+++ b/my-app/src/App.jsx
@@ -1,8 +1,9 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 
 function App() {
   const [items, setItems] = useState([])
   const [text, setText] = useState('')
+  const dragId = useRef(null)
 
   const addItem = (e) => {
     if (e) e.preventDefault()
@@ -15,6 +16,33 @@ function App() {
 
   const deleteItem = (id) => {
     setItems((prev) => prev.filter((item) => item.id !== id))
+  }
+
+  const handleDrop = (overId) => {
+    const dragged = dragId.current
+    if (dragged === null || dragged === overId) return
+    setItems((prev) => {
+      const dragIndex = prev.findIndex((i) => i.id === dragged)
+      const overIndex = prev.findIndex((i) => i.id === overId)
+      if (dragIndex === -1 || overIndex === -1) return prev
+      const updated = [...prev]
+      const [removed] = updated.splice(dragIndex, 1)
+      updated.splice(overIndex, 0, removed)
+      return updated
+    })
+  }
+
+  const handleDropToEnd = () => {
+    const dragged = dragId.current
+    if (dragged === null) return
+    setItems((prev) => {
+      const dragIndex = prev.findIndex((i) => i.id === dragged)
+      if (dragIndex === -1 || dragIndex === prev.length - 1) return prev
+      const updated = [...prev]
+      const [removed] = updated.splice(dragIndex, 1)
+      updated.push(removed)
+      return updated
+    })
   }
 
   return (
@@ -34,10 +62,19 @@ function App() {
           Add
         </button>
       </form>
-      <ul>
+      <ul onDragOver={(e) => e.preventDefault()} onDrop={handleDropToEnd}>
         {items.map((item) => (
           <li
             key={item.id}
+            draggable
+            onDragStart={() => {
+              dragId.current = item.id
+            }}
+            onDragEnd={() => {
+              dragId.current = null
+            }}
+            onDragOver={(e) => e.preventDefault()}
+            onDrop={() => handleDrop(item.id)}
             className="flex items-center justify-between p-2 mb-2 bg-gray-50 border rounded"
           >
             <span>{item.text}</span>


### PR DESCRIPTION
## Summary
- allow items to be reordered by dragging them

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6846f449aa348333a40ff3b98ff78e4d